### PR TITLE
Update arducam_arch_raspberrypi.c

### DIFF
--- a/ArduCAM/examples/RaspberryPi/arducam_arch_raspberrypi.c
+++ b/ArduCAM/examples/RaspberryPi/arducam_arch_raspberrypi.c
@@ -122,7 +122,7 @@ uint8_t arducam_i2c_word_write(uint16_t regID, uint8_t regDat)
 	value =  regDat << 8 | reg_L;
 	if(FD != -1)
 	{
-		i2c_smbus_write_word_data(FD, reg_H, value);
+		i2c_smbus_ioctl_data(FD, reg_H, value);
 		arducam_delay_ms(1);
 		return(1);
 	}
@@ -137,10 +137,10 @@ uint8_t arducam_i2c_word_read(uint16_t regID, uint8_t* regDat)
 	reg_L = regID & 0x00ff;
 	if(FD != -1)
 	{
-		r = i2c_smbus_write_byte_data(FD,reg_H,reg_L);
+		r = i2c_smbus_ioctl_data(FD,reg_H,reg_L);
 		if(r<0)
 			return 0;
-		*regDat = i2c_smbus_read_byte(FD);
+		*regDat = i2c_smbus_data(FD);
 		return(1);
 	}
 	return 0;


### PR DESCRIPTION
make
g++ -std=c++0x -I../../../ArduCAM -I./ -c ../../../ArduCAM/ArduCAM.cpp
g++ -std=c++0x -I./ -I../../../ArduCAM -c arducam_arch_raspberrypi.c 
arducam_arch_raspberrypi.c: In function ‘uint8_t arducam_i2c_word_write(uint16_t, uint8_t)’:
arducam_arch_raspberrypi.c:125:3: error: ‘i2c_smbus_write_word_data’ was not declared in this scope
   i2c_smbus_write_word_data(FD, reg_H, value);
   ^~~~~~~~~~~~~~~~~~~~~~~~~
arducam_arch_raspberrypi.c:125:3: note: suggested alternative: ‘i2c_smbus_ioctl_data’
   i2c_smbus_write_word_data(FD, reg_H, value);
   ^~~~~~~~~~~~~~~~~~~~~~~~~
   i2c_smbus_ioctl_data
arducam_arch_raspberrypi.c: In function ‘uint8_t arducam_i2c_word_read(uint16_t, uint8_t*)’:
arducam_arch_raspberrypi.c:140:7: error: ‘i2c_smbus_write_byte_data’ was not declared in this scope
   r = i2c_smbus_write_byte_data(FD,reg_H,reg_L);
       ^~~~~~~~~~~~~~~~~~~~~~~~~
arducam_arch_raspberrypi.c:140:7: note: suggested alternative: ‘i2c_smbus_ioctl_data’
   r = i2c_smbus_write_byte_data(FD,reg_H,reg_L);
       ^~~~~~~~~~~~~~~~~~~~~~~~~
       i2c_smbus_ioctl_data
arducam_arch_raspberrypi.c:143:13: error: ‘i2c_smbus_read_byte’ was not declared in this scope
   *regDat = i2c_smbus_read_byte(FD);
             ^~~~~~~~~~~~~~~~~~~
arducam_arch_raspberrypi.c:143:13: note: suggested alternative: ‘i2c_smbus_data’
   *regDat = i2c_smbus_read_byte(FD);
             ^~~~~~~~~~~~~~~~~~~
             i2c_smbus_data
make: *** [makefile:27: arducam_arch_raspberrypi.o] Error 1
